### PR TITLE
Fix: Apply residue loop to Restraint classes instead of using only C-terminal

### DIFF
--- a/pyext/src/restraints/npc.py
+++ b/pyext/src/restraints/npc.py
@@ -70,13 +70,10 @@ class XYRadialPositionLowerRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, lower_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        
-        #cterminal = residues[-1] #This is OLD line. This considers only cterminal residue
-        #xyr.add_particle(cterminal) #This is OLD line. This considers only cterminal residue
-        
+
         for residue in residues:
             xyr.add_particle(residue)
-        
+
         self.rs.add_restraint(xyr)
 
 
@@ -96,9 +93,6 @@ class XYRadialPositionUpperRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, upper_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        
-        #cterminal = residues[-1]  #This is OLD line. This considers only cterminal residue
-        #xyr.add_particle(cterminal)  #This is OLD line. This considers only cterminal residue
 
         for residue in residues:
             xyr.add_particle(residue)
@@ -159,9 +153,7 @@ class ZAxialPositionLowerRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, lower_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        
-        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
-        #zax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
+
         for residue in residues:
             zax.add_particle(residue)
 
@@ -184,9 +176,7 @@ class ZAxialPositionUpperRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, upper_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        
-        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
-        #zax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
+
         for residue in residues:
             zax.add_particle(residue)
 
@@ -248,8 +238,6 @@ class YAxialPositionLowerRestraint(IMP.pmi.restraints.RestraintBase):
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
 
-        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
-        #yax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
         for residue in residues:
             yax.add_particle(residue)
 
@@ -273,8 +261,6 @@ class YAxialPositionUpperRestraint(IMP.pmi.restraints.RestraintBase):
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
 
-        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
-        #yax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
         for residue in residues:
             yax.add_particle(residue)
 

--- a/pyext/src/restraints/npc.py
+++ b/pyext/src/restraints/npc.py
@@ -70,9 +70,13 @@ class XYRadialPositionLowerRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, lower_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        cterminal = residues[-1]
-
-        xyr.add_particle(cterminal)
+        
+        #cterminal = residues[-1] #This is OLD line. This considers only cterminal residue
+        #xyr.add_particle(cterminal) #This is OLD line. This considers only cterminal residue
+        
+        for residue in residues:
+            xyr.add_particle(residue)
+        
         self.rs.add_restraint(xyr)
 
 
@@ -92,9 +96,12 @@ class XYRadialPositionUpperRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, upper_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        cterminal = residues[-1]
+        
+        #cterminal = residues[-1]  #This is OLD line. This considers only cterminal residue
+        #xyr.add_particle(cterminal)  #This is OLD line. This considers only cterminal residue
 
-        xyr.add_particle(cterminal)
+        for residue in residues:
+            xyr.add_particle(residue)
         self.rs.add_restraint(xyr)
 
 
@@ -152,9 +159,12 @@ class ZAxialPositionLowerRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, lower_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        cterminal = residues[-1]
+        
+        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
+        #zax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
+        for residue in residues:
+            zax.add_particle(residue)
 
-        zax.add_particle(cterminal)
         self.rs.add_restraint(zax)
 
 
@@ -174,9 +184,12 @@ class ZAxialPositionUpperRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, upper_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        cterminal = residues[-1]
+        
+        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
+        #zax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
+        for residue in residues:
+            zax.add_particle(residue)
 
-        zax.add_particle(cterminal)
         self.rs.add_restraint(zax)
 
 
@@ -234,9 +247,12 @@ class YAxialPositionLowerRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, lower_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        cterminal = residues[-1]
 
-        yax.add_particle(cterminal)
+        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
+        #yax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
+        for residue in residues:
+            yax.add_particle(residue)
+
         self.rs.add_restraint(yax)
 
 
@@ -256,9 +272,12 @@ class YAxialPositionUpperRestraint(IMP.pmi.restraints.RestraintBase):
             self.model, upper_bound, consider_radius, sigma)
         residues = IMP.pmi.tools.select_by_tuple_2(
             hier, protein, resolution=1)
-        cterminal = residues[-1]
 
-        yax.add_particle(cterminal)
+        #cterminal = residues[-1]   #This is OLD line. This considers only cterminal residue
+        #yax.add_particle(cterminal)   #This is OLD line. This considers only cterminal residue
+        for residue in residues:
+            yax.add_particle(residue)
+
         self.rs.add_restraint(yax)
 
 

--- a/test/test_npc.py
+++ b/test/test_npc.py
@@ -41,7 +41,7 @@ class Tests(IMP.test.TestCase):
         out = r.get_output()
         self.assertAlmostEqual(
             float(out['XYRadialPositionLowerRestraint_Score_Test']),
-            33.74, delta=1e-2)
+            53.37, delta=1e-2)
 
     def test_xy_radial_pos_upper_restraint(self):
         """Test XYRadialPositionUpperRestraint"""
@@ -53,7 +53,7 @@ class Tests(IMP.test.TestCase):
         out = r.get_output()
         self.assertAlmostEqual(
             float(out['XYRadialPositionUpperRestraint_Score_Test']),
-            84.48, delta=1e-2)
+            196.19, delta=1e-2)
 
     def test_z_axial_pos_restraint(self):
         """Test ZAxialPositionRestraint"""
@@ -76,7 +76,7 @@ class Tests(IMP.test.TestCase):
         out = r.get_output()
         self.assertAlmostEqual(
             float(out['ZAxialPositionLowerRestraint_Score_Test']),
-            62.76, delta=1e-2)
+            90.38, delta=1e-2)
 
     def test_z_axial_pos_upper_restraint(self):
         """Test ZAxialPositionUpperRestraint"""
@@ -87,7 +87,7 @@ class Tests(IMP.test.TestCase):
         out = r.get_output()
         self.assertAlmostEqual(
             float(out['ZAxialPositionUpperRestraint_Score_Test']),
-            4.32, delta=1e-2)
+            26.82, delta=1e-2)
 
     def test_y_axial_pos_restraint(self):
         """Test YAxialPositionRestraint"""
@@ -110,7 +110,7 @@ class Tests(IMP.test.TestCase):
         out = r.get_output()
         self.assertAlmostEqual(
             float(out['YAxialPositionLowerRestraint_Score_Test']),
-            21.64, delta=1e-2)
+            53.42, delta=1e-2)
 
     def test_y_axial_pos_upper_restraint(self):
         """Test YAxialPositionUpperRestraint"""
@@ -121,7 +121,7 @@ class Tests(IMP.test.TestCase):
         out = r.get_output()
         self.assertAlmostEqual(
             float(out['YAxialPositionUpperRestraint_Score_Test']),
-            5.51, delta=1e-2)
+            7.36, delta=1e-2)
 
     def test_membrane_surface_restraint(self):
         """Test MembraneSurfaceLocationRestraint"""


### PR DESCRIPTION
Replaced the previous logic that added only the C-terminal residue to the restraint setup with a loop over all residues. This change was applied to the following classes:

- XYRadialPositionLowerRestraint  
- XYRadialPositionUpperRestraint  
- ZAxialPositionLowerRestraint  
- ZAxialPositionUpperRestraint  
- YAxialPositionLowerRestraint  
- YAxialPositionUpperRestraint  

Ensures that all residues are correctly added to xyr or other related data structures, improving restraint application consistency across the full molecule or selection.
